### PR TITLE
fix 403 error

### DIFF
--- a/src/main/java/org/wdf/wdf/WdfProjectBackApplication.java
+++ b/src/main/java/org/wdf/wdf/WdfProjectBackApplication.java
@@ -27,6 +27,7 @@ public class WdfProjectBackApplication implements CommandLineRunner{
 	public void run(String... args) throws Exception {
 		// TODO Auto-generated method stub	
 		Utilisateur user=new Utilisateur();
+		utilisateurRepository.deleteAll();
 		user.setNom("admin");
 		user.setPrenom("admin");
 		user.setLogin("admin");

--- a/src/main/java/org/wdf/wdf/security/SecurityConfig.java
+++ b/src/main/java/org/wdf/wdf/security/SecurityConfig.java
@@ -32,6 +32,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter{
 	protected void configure(HttpSecurity http) throws Exception {
 		http.csrf().disable();
 		http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+		http.authorizeRequests().antMatchers("/").permitAll();	
+		http.authorizeRequests().antMatchers("/assets/**").permitAll();	
+		http.authorizeRequests().antMatchers("**js**").permitAll();	
+		http.authorizeRequests().antMatchers("**css**").permitAll();	
+		http.authorizeRequests().antMatchers("**html**").permitAll();	
 		http.authorizeRequests().antMatchers("/login/**").permitAll();	
 		http.authorizeRequests().antMatchers("/api/formation/list/**").permitAll();
 		http.authorizeRequests().antMatchers("/api/depistage/list/**").permitAll();


### PR DESCRIPTION
This solves the issues related to preventing the user from logging in, because the login page show up when hitting the <host>:<port>/ , and the security config was blocking that path for non-authenticated calls, so I had to add it to the permitted paths (which can be called with no authentication), I also did the same thing for assets.